### PR TITLE
Remove appVersion

### DIFF
--- a/charts/nobl9-agent/Chart.yaml
+++ b/charts/nobl9-agent/Chart.yaml
@@ -1,7 +1,6 @@
 apiVersion: v2
 name: nobl9-agent
-version: 1.0.0
-appVersion: 0.48.0
+version: 1.0.1
 description: Agent to retrieve SLI metrics from configured data sources and send the data back to the Nobl9 backend.
 home: https://nobl9.com
 sources:

--- a/charts/nobl9-agent/README.md
+++ b/charts/nobl9-agent/README.md
@@ -1,6 +1,6 @@
 # nobl9-agent
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 0.48.0](https://img.shields.io/badge/AppVersion-0.48.0-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square)
 
 Agent to retrieve SLI metrics from configured data sources and send the data back to the Nobl9 backend.
 


### PR DESCRIPTION
The chart version is not strictly associated with app version. `deployment.version` field of `values.yml` provides a way to manage app version.