### PR TITLE
Add ability to mount extra volumes

### DIFF
--- a/charts/nobl9-agent/Chart.yaml
+++ b/charts/nobl9-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nobl9-agent
-version: 1.0.3
+version: 1.0.4
 description: Agent to retrieve SLI metrics from configured data sources and send the data back to the Nobl9 backend.
 home: https://nobl9.com
 sources:

--- a/charts/nobl9-agent/README.md
+++ b/charts/nobl9-agent/README.md
@@ -89,6 +89,8 @@ Go to the [docs.nobl9.com](https://docs.nobl9.com/Nobl9_Agent/helm-charts?_highl
 | config.project | string | `nil` | Nobl9 Project name |
 | deployment.annotations | object | `{}` | Custom annotations |
 | deployment.extraEnvs | string | `nil` | Additional Envs |
+| deployment.extraVolumeMounts | string | `nil` | Additional Volume mounts |
+| deployment.extraVolumes | string | `nil` | Additional Volumes |
 | deployment.image | string | `"nobl9/agent"` | Image used by chart |
 | deployment.pullPolicy | string | `"Always"` | Image Pull Policy |
 | deployment.version | string | `"0.53.2"` | Agent version (image tag) |

--- a/charts/nobl9-agent/templates/deployment.yaml
+++ b/charts/nobl9-agent/templates/deployment.yaml
@@ -60,5 +60,14 @@ spec:
             {{- with .Values.deployment.extraEnvs }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- with .Values.deployment.extraVolumeMounts }}
+          volumeMounts:
+              {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+      {{- with .Values.deployment.extraVolumes }}
+      volumes:
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
+

--- a/charts/nobl9-agent/values.yaml
+++ b/charts/nobl9-agent/values.yaml
@@ -29,6 +29,17 @@ deployment:
   #     secretKeyRef:
   #       key: client_secret
   #       name: my-existing-secret
+  # -- Additional Volumes
+  extraVolumes:
+  # - name: gcp-credentials
+  #   secret:
+  #     defaultMode: 420
+  #     secretName: my-bigquery-secret-file
+  # -- Additional Volume mounts
+  extraVolumeMounts:
+  # - mountPath: /var/gcp
+  #   name: gcp-credentials
+  #   readOnly: true
   # -- Custom annotations
   annotations: {}
   # -- Additional Labels


### PR DESCRIPTION
This change introduces `deployment.extraVolumes` and `deployment.extraVolumeMounts` to enable user defined volumes for example to use with BigQuery or GCM integration.