### PR TITLE
feat: add affinity and nodeSelector options for agent chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+# Generates README.md file based on template. Requires helm-docs to be installed (https://github.com/norwoodj/helm-docs).
+generate-helm-docs:
+	helm-docs

--- a/charts/nobl9-agent/Chart.yaml
+++ b/charts/nobl9-agent/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: nobl9-agent
-version: 1.0.7
+version: 1.0.8
 description: Agent to retrieve SLI metrics from configured data sources and send the data back to the Nobl9 backend.
 home: https://nobl9.com
 sources:

--- a/charts/nobl9-agent/README.md
+++ b/charts/nobl9-agent/README.md
@@ -89,7 +89,7 @@ Go to the [docs.nobl9.com](https://docs.nobl9.com/Nobl9_Agent/helm-charts?_highl
 | config.oktaOrgUrl | string | `"https://accounts.nobl9.com"` | Nobl9 Okta Organization URL |
 | config.organization | string | `nil` | Nobl9 Organization name |
 | config.project | string | `nil` | Nobl9 Project name |
-| deployment.affinity | object | `{}` | Node affiniti |
+| deployment.affinity | object | `{}` | Affinity settings |
 | deployment.annotations | object | `{}` | Custom annotations |
 | deployment.extraEnvs | string | `nil` | Additional Envs |
 | deployment.extraVolumeMounts | string | `nil` | Additional Volume mounts |

--- a/charts/nobl9-agent/README.md
+++ b/charts/nobl9-agent/README.md
@@ -89,11 +89,13 @@ Go to the [docs.nobl9.com](https://docs.nobl9.com/Nobl9_Agent/helm-charts?_highl
 | config.oktaOrgUrl | string | `"https://accounts.nobl9.com"` | Nobl9 Okta Organization URL |
 | config.organization | string | `nil` | Nobl9 Organization name |
 | config.project | string | `nil` | Nobl9 Project name |
+| deployment.affinity | object | `{}` | Node affiniti |
 | deployment.annotations | object | `{}` | Custom annotations |
 | deployment.extraEnvs | string | `nil` | Additional Envs |
 | deployment.extraVolumeMounts | string | `nil` | Additional Volume mounts |
 | deployment.extraVolumes | string | `nil` | Additional Volumes |
 | deployment.image | string | `"nobl9/agent"` | Image used by chart |
+| deployment.nodeSelector | object | `{}` | Node selector |
 | deployment.pullPolicy | string | `"Always"` | Image Pull Policy |
 | deployment.version | string | `"0.69.2"` | Agent version (image tag) |
 | extraLabels | object | `{}` | Additional labels for created objects. |

--- a/charts/nobl9-agent/templates/deployment.yaml
+++ b/charts/nobl9-agent/templates/deployment.yaml
@@ -78,4 +78,11 @@ spec:
       volumes:
           {{- toYaml . | nindent 8 }}
       {{- end }}
-
+      {{- with .Values.deployment.nodeSelector }}
+      nodeSelector:
+          {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.deployment.affinity }}
+      affinity:
+          {{- toYaml . | nindent 8 }}
+      {{- end}}

--- a/charts/nobl9-agent/values.schema.json
+++ b/charts/nobl9-agent/values.schema.json
@@ -100,6 +100,14 @@
         "annotations": {
           "type": "object",
           "description": "Custom annotations"
+        },
+        "nodeSelector": {
+          "type": "object",
+          "description": "Key value pairs for node selector"
+        },
+        "affinity": {
+          "type": "object",
+          "description": "Affinity settings"
         }
       }
     },

--- a/charts/nobl9-agent/values.yaml
+++ b/charts/nobl9-agent/values.yaml
@@ -43,10 +43,10 @@ deployment:
   # -- Custom annotations
   annotations: {}
   # -- Node selector
-  nodeSelector:
+  nodeSelector: {}
   # disktype: ssd
   # -- Node affiniti
-  affinity:
+  affinity: {}
   # nodeAffinity:
   #   requiredDuringSchedulingIgnoredDuringExecution:
   #     nodeSelectorTerms:

--- a/charts/nobl9-agent/values.yaml
+++ b/charts/nobl9-agent/values.yaml
@@ -42,7 +42,28 @@ deployment:
   #   readOnly: true
   # -- Custom annotations
   annotations: {}
-  # -- Additional Labels
+  # -- Node selector
+  nodeSelector:
+  # disktype: ssd
+  # -- Node affiniti
+  affinity:
+  # nodeAffinity:
+  #   requiredDuringSchedulingIgnoredDuringExecution:
+  #     nodeSelectorTerms:
+  #     - matchExpressions:
+  #       - key: topology.kubernetes.io/zone
+  #         operator: In
+  #         values:
+  #         - antarctica-east1
+  #         - antarctica-west1
+  #   preferredDuringSchedulingIgnoredDuringExecution:
+  #   - weight: 1
+  #     preference:
+  #       matchExpressions:
+  #       - key: another-node-label-key
+  #         operator: In
+  #         values:
+  #         - another-node-label-value
 
 secret:
   # -- Override the Secret name

--- a/charts/nobl9-agent/values.yaml
+++ b/charts/nobl9-agent/values.yaml
@@ -45,7 +45,7 @@ deployment:
   # -- Node selector
   nodeSelector: {}
   # disktype: ssd
-  # -- Node affiniti
+  # -- Affinity settings
   affinity: {}
   # nodeAffinity:
   #   requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
## Summary
Add helm values for the `nodeSelector` and the `affinity` settings and implement them in the deployment template.