### PR TITLE
feat: Add tolerations to agent deployment

### DIFF
--- a/charts/nobl9-agent/templates/deployment.yaml
+++ b/charts/nobl9-agent/templates/deployment.yaml
@@ -86,3 +86,7 @@ spec:
       affinity:
           {{- toYaml . | nindent 8 }}
       {{- end}}
+      {{- with .Values.deployment.tolerations }}
+      tolerations:
+          {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/nobl9-agent/values.yaml
+++ b/charts/nobl9-agent/values.yaml
@@ -45,6 +45,7 @@ deployment:
   # -- Node selector
   nodeSelector: {}
   # disktype: ssd
+  tolerations: []
   # -- Affinity settings
   affinity: {}
   # nodeAffinity:

--- a/charts/nobl9-agent/values.yaml
+++ b/charts/nobl9-agent/values.yaml
@@ -45,7 +45,16 @@ deployment:
   # -- Node selector
   nodeSelector: {}
   # disktype: ssd
+  # -- Tolerations
   tolerations: []
+  # tolerations:
+  #  - key: "key1"
+  #    operator: "Equal"
+  #    value: "value1"
+  #    effect: "NoSchedule"
+  #  - key: "key2"
+  #    operator: "Exists"
+  #    effect: "NoSchedule"
   # -- Affinity settings
   affinity: {}
   # nodeAffinity:


### PR DESCRIPTION
Added ability to specify tolerations in the agent helm chart.

Can be tested with custom `values.yaml` file like:
```yaml
deployment:
  tolerations:
    - key: "key"
      operator: "Equal|Exists"
      value: "value"
      effect: "NoSchedule|PreferNoSchedule"
```